### PR TITLE
Avoid ValueError when not running in main thread

### DIFF
--- a/tokeniser.py
+++ b/tokeniser.py
@@ -3,6 +3,7 @@
 import re
 import codecs
 import sys
+import threading
 
 if sys.platform == 'win32':
   from signal import signal, SIG_DFL
@@ -10,7 +11,8 @@ else:
   from signal import signal, SIGPIPE, SIG_DFL
 
 if sys.platform != 'win32':
-  signal(SIGPIPE, SIG_DFL)
+    if threading.current_thread() is threading.main_thread():
+        signal(SIGPIPE, SIG_DFL)
 
 import os
 reldir=os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
This update prevents the _ValueError_ exception when using reldi-tokeniser in multi-threaded code, e.g., when used as a service in a multi-threaded server.